### PR TITLE
CO-9795: update version of chef-ruby-lvm-attrib to 0.2.8

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,6 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.2.6'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.2.8'
 default['lvm']['cleanup_old_gems'] = true
 default['lvm']['rubysource'] = 'https://rubygems.org'


### PR DESCRIPTION
###
JIRA

Main Ticket - https://coupadev.atlassian.net/browse/CO-9795

### Description

Update the version of chef-ruby-lvm-attrib from 0.2.6 to 0.2.8 to include the attribute file for 2.02.185 added by https://github.com/chef/chef-ruby-lvm-attrib/pull/13/files?file-filters%5B%5D=

### Reviewers
- [x] @pallav-jakhotiya 
- [ ] @pkazi 
- [x] @Ramesh7 

### Testing
- [x] Manual