### PR TITLE
CO-11298 : Updating chef-ruby-lvm-attrib version to support lvm2 2.02…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,6 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.2.8'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.0'
 default['lvm']['cleanup_old_gems'] = true
 default['lvm']['rubysource'] = 'https://rubygems.org'


### PR DESCRIPTION
….186 version

### Description

New AMI launching with lvm2 2.02.186 which is not yet supported with chef-ruby-lvm-attrs gem, so we need to upgrade to 0.3.0 which supports the same.

### Issues Resolved

Updating chef-ruby-lvm-attrs to 0.3.0.
