### PR TITLE
CO-11298 5.3   Updating chef-ruby-lvm-attrib version to support lvm2 2.02

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,6 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.2.8'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.0'
 default['lvm']['cleanup_old_gems'] = true
 default['lvm']['rubysource'] = 'https://rubygems.org'


### PR DESCRIPTION
https://github.com/coupa-ops/lvm/pull/3 to 5.3