### PR TITLE
CE-12802 [5.5] upgrade chef-ruby-lvm-attrib gem version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,7 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.0'
+# Refer for latest supported version - https://github.com/chef/chef-ruby-lvm-attrib/blob/master/CHANGELOG.md
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.6'
 default['lvm']['cleanup_old_gems'] = true
 default['lvm']['rubysource'] = 'https://rubygems.org'


### PR DESCRIPTION
https://coupadev.atlassian.net/browse/CE-12802

## Description
5.5.p7 AMI launching with lvm2 2.02.187 which is not yet supported with chef-ruby-lvm-attrs gem, so we need to upgrade to 0.3.6 which supports the same.

## Issues Resolved
Updating chef-ruby-lvm-attrs to 0.3.6.